### PR TITLE
Ensure that response body is closed by PIP client

### DIFF
--- a/pipclient/pipclient.go
+++ b/pipclient/pipclient.go
@@ -39,6 +39,8 @@ func (client *PIPClient) PointInPolygon(latitude string, longitude string) (*Pla
 		return nil, err
 	}
 
+	defer res.Body.Close()
+	
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR ensures that the response body (for a request to the PIP server) is closed by PIP client. Without this the code risks running out of file handles.